### PR TITLE
Add JSON-based renderer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,6 +312,23 @@ endif()
 
 target_link_libraries(${PROJECT_NAME} PRIVATE ${MAIN_LINK_LIBRARIES})
 
+add_executable(render_json tools/render_from_json.cpp)
+set_target_properties(render_json PROPERTIES
+        CUDA_ARCHITECTURES native
+        CUDA_SEPARABLE_COMPILATION ON
+        CUDA_RESOLVE_DEVICE_SYMBOLS ON
+)
+target_include_directories(render_json
+        PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_BINARY_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/gsplat
+        ${Python3_INCLUDE_DIRS}
+        ${CUDAToolkit_INCLUDE_DIRS}
+        ${OPENGL_INCLUDE_DIRS}
+)
+target_link_libraries(render_json PRIVATE ${MAIN_LINK_LIBRARIES})
+
 # Platform-specific settings
 if(WIN32)
     file(GLOB TORCH_DLLS "${Torch_DIR}/../../../lib/*.dll")
@@ -370,6 +387,7 @@ if(CUDA_GL_INTEROP_FOUND AND TARGET gaussian_visualizer)
     configure_build_type(gaussian_visualizer)
 endif()
 configure_build_type(${PROJECT_NAME})
+configure_build_type(render_json)
 
 # =============================================================================
 # TESTING (Optional)

--- a/tools/render_from_json.cpp
+++ b/tools/render_from_json.cpp
@@ -1,0 +1,101 @@
+#include "core/camera.hpp"
+#include "core/image_io.hpp"
+#include "core/ply_loader.hpp"
+#include "core/rasterizer.hpp"
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <nlohmann/json.hpp>
+
+int main(int argc, char** argv) {
+    if (argc < 4) {
+        std::cerr << "Usage: " << argv[0] << " <ply_file> <camera_json> <output_dir>\n";
+        return 1;
+    }
+    std::filesystem::path ply_path = argv[1];
+    std::filesystem::path json_path = argv[2];
+    std::filesystem::path out_dir = argv[3];
+
+    if (!std::filesystem::exists(ply_path)) {
+        std::cerr << "PLY file not found: " << ply_path << "\n";
+        return 1;
+    }
+    if (!std::filesystem::exists(json_path)) {
+        std::cerr << "Camera JSON file not found: " << json_path << "\n";
+        return 1;
+    }
+    std::filesystem::create_directories(out_dir);
+
+    auto splat_result = gs::load_ply(ply_path);
+    if (!splat_result) {
+        std::cerr << "Failed to load PLY: " << splat_result.error() << "\n";
+        return 1;
+    }
+    gs::SplatData model = std::move(*splat_result);
+
+    std::ifstream json_stream(json_path);
+    nlohmann::json json;
+    json_stream >> json;
+
+    std::vector<nlohmann::json> cameras;
+    if (json.is_array()) {
+        cameras.assign(json.begin(), json.end());
+    } else if (json.is_object()) {
+        cameras.push_back(json);
+    } else {
+        std::cerr << "Invalid JSON format\n";
+        return 1;
+    }
+
+    torch::Tensor bg_color = torch::zeros({3});
+    int cam_idx = 0;
+    for (const auto& cam_json : cameras) {
+        if (!cam_json.contains("intrinsics") || !cam_json.contains("extrinsics")) {
+            std::cerr << "Camera entry missing intrinsics or extrinsics\n";
+            continue;
+        }
+        auto intr = cam_json["intrinsics"];
+        auto ext = cam_json["extrinsics"]["c2w_matrix"];
+        int width = cam_json.value("width", 0);
+        int height = cam_json.value("height", 0);
+        std::string img_id = cam_json.value("img_id", std::to_string(cam_idx));
+
+        torch::Tensor c2w = torch::empty({4, 4}, torch::kFloat32);
+        for (int i = 0; i < 4; ++i) {
+            for (int j = 0; j < 4; ++j) {
+                c2w[i][j] = static_cast<float>(ext[i][j]);
+            }
+        }
+        torch::Tensor w2c = torch::inverse(c2w);
+        torch::Tensor R = w2c.index({torch::indexing::Slice(0, 3), torch::indexing::Slice(0, 3)});
+        torch::Tensor T = w2c.index({torch::indexing::Slice(0, 3), 3});
+
+        float fx = intr[0][0];
+        float fy = intr[1][1];
+        float cx = intr[0][2];
+        float cy = intr[1][2];
+
+        Camera cam(R,
+                   T,
+                   fx,
+                   fy,
+                   cx,
+                   cy,
+                   torch::empty({0}, torch::kFloat32),
+                   torch::empty({0}, torch::kFloat32),
+                   gsplat::CameraModelType::PINHOLE,
+                   img_id,
+                   "",
+                   width,
+                   height,
+                   cam_idx);
+
+        auto output = gs::rasterize(cam, model, bg_color);
+        std::filesystem::path out_path = out_dir / (img_id + ".png");
+        gs::save_image(out_path, output.image);
+        std::cout << "Saved " << out_path << "\n";
+        ++cam_idx;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- create a small `render_json` tool that loads a gaussian PLY and a JSON file with camera parameters
- build the new tool via CMake

## Testing
- `bash tools/pre-commit`
- `cmake -S . -B build -GNinja` *(fails: Could not find toolchain file)*

------
https://chatgpt.com/codex/tasks/task_e_68821787c108832981f4a3a520852b40