### PR TITLE
Add CLI parsing for render_json tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,6 +312,23 @@ endif()
 
 target_link_libraries(${PROJECT_NAME} PRIVATE ${MAIN_LINK_LIBRARIES})
 
+add_executable(render_json tools/render_from_json.cpp)
+set_target_properties(render_json PROPERTIES
+        CUDA_ARCHITECTURES native
+        CUDA_SEPARABLE_COMPILATION ON
+        CUDA_RESOLVE_DEVICE_SYMBOLS ON
+)
+target_include_directories(render_json
+        PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_BINARY_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/gsplat
+        ${Python3_INCLUDE_DIRS}
+        ${CUDAToolkit_INCLUDE_DIRS}
+        ${OPENGL_INCLUDE_DIRS}
+)
+target_link_libraries(render_json PRIVATE ${MAIN_LINK_LIBRARIES})
+
 # Platform-specific settings
 if(WIN32)
     file(GLOB TORCH_DLLS "${Torch_DIR}/../../../lib/*.dll")
@@ -321,6 +338,13 @@ if(WIN32)
                 POST_BUILD
                 COMMAND ${CMAKE_COMMAND} -E copy_if_different "${TORCH_DLL}"
                 "$<TARGET_FILE_DIR:${PROJECT_NAME}>")
+    endforeach()
+    foreach(TORCH_DLL ${TORCH_DLLS})
+        add_custom_command(
+                TARGET render_json
+                POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different "${TORCH_DLL}"
+                "$<TARGET_FILE_DIR:render_json>")
     endforeach()
 elseif(UNIX)
     target_link_libraries(${PROJECT_NAME} PRIVATE GL GLU)
@@ -370,6 +394,7 @@ if(CUDA_GL_INTEROP_FOUND AND TARGET gaussian_visualizer)
     configure_build_type(gaussian_visualizer)
 endif()
 configure_build_type(${PROJECT_NAME})
+configure_build_type(render_json)
 
 # =============================================================================
 # TESTING (Optional)

--- a/README.md
+++ b/README.md
@@ -278,6 +278,16 @@ GPU acceleration and GUI support (e.g., OpenGL viewers) are enabled if supported
 4. Clean your build directory: `rm -rf build/`
 5. Rebuild the project
 
+### Render from Camera JSON
+Builds on both Linux and Windows include a helper executable `render_json`.
+It loads a Gaussian PLY along with a JSON file of camera parameters and
+outputs a rendered PNG for each camera entry.
+
+```bash
+./build/render_json <model.ply> cameras.json output/
+Run `./build/render_json --help` for all options.
+```
+
 ## Dataset
 
 Download the dataset from the original repository:

--- a/tools/render_from_json.cpp
+++ b/tools/render_from_json.cpp
@@ -1,0 +1,126 @@
+#include "core/camera.hpp"
+#include "core/image_io.hpp"
+#include "core/ply_loader.hpp"
+#include "core/rasterizer.hpp"
+#include <args.hxx>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <nlohmann/json.hpp>
+
+int main(int argc, char** argv) {
+    args::ArgumentParser parser(
+        "Render Gaussian Splat from JSON cameras",
+        "Renders a PLY Gaussian model using cameras provided in a JSON array.");
+
+    args::HelpFlag help(parser, "help", "Display this help menu", {'h', "help"});
+    args::ValueFlag<std::string> ply_arg(
+        parser, "ply", "Path to the Gaussian PLY model", {'p', "ply"});
+    args::ValueFlag<std::string> json_arg(
+        parser, "json", "Camera JSON file", {'j', "json"});
+    args::ValueFlag<std::string> out_arg(
+        parser, "output", "Output directory", {'o', "output"});
+
+    try {
+        parser.ParseCLI(argc, argv);
+    } catch (const args::Help&) {
+        std::cout << parser.Help();
+        return 0;
+    } catch (const args::ParseError& e) {
+        std::cerr << e.what() << '\n'
+                  << parser.Help();
+        return 1;
+    }
+
+    if (!ply_arg || !json_arg || !out_arg) {
+        std::cerr << parser.Help();
+        return 1;
+    }
+
+    std::filesystem::path ply_path = args::get(ply_arg);
+    std::filesystem::path json_path = args::get(json_arg);
+    std::filesystem::path out_dir = args::get(out_arg);
+
+    if (!std::filesystem::exists(ply_path)) {
+        std::cerr << "PLY file not found: " << ply_path << "\n";
+        return 1;
+    }
+    if (!std::filesystem::exists(json_path)) {
+        std::cerr << "Camera JSON file not found: " << json_path << "\n";
+        return 1;
+    }
+    std::filesystem::create_directories(out_dir);
+
+    auto splat_result = gs::load_ply(ply_path);
+    if (!splat_result) {
+        std::cerr << "Failed to load PLY: " << splat_result.error() << "\n";
+        return 1;
+    }
+    gs::SplatData model = std::move(*splat_result);
+
+    std::ifstream json_stream(json_path);
+    nlohmann::json json;
+    json_stream >> json;
+
+    std::vector<nlohmann::json> cameras;
+    if (json.is_array()) {
+        cameras.assign(json.begin(), json.end());
+    } else if (json.is_object()) {
+        cameras.push_back(json);
+    } else {
+        std::cerr << "Invalid JSON format\n";
+        return 1;
+    }
+
+    torch::Tensor bg_color = torch::zeros({3});
+    int cam_idx = 0;
+    for (const auto& cam_json : cameras) {
+        if (!cam_json.contains("intrinsics") || !cam_json.contains("extrinsics")) {
+            std::cerr << "Camera entry missing intrinsics or extrinsics\n";
+            continue;
+        }
+        auto intr = cam_json["intrinsics"];
+        auto ext = cam_json["extrinsics"]["c2w_matrix"];
+        int width = cam_json.value("width", 0);
+        int height = cam_json.value("height", 0);
+        std::string img_id = cam_json.value("img_id", std::to_string(cam_idx));
+
+        torch::Tensor c2w = torch::empty({4, 4}, torch::kFloat32);
+        for (int i = 0; i < 4; ++i) {
+            for (int j = 0; j < 4; ++j) {
+                c2w[i][j] = static_cast<float>(ext[i][j]);
+            }
+        }
+        torch::Tensor w2c = torch::inverse(c2w);
+        torch::Tensor R = w2c.index({torch::indexing::Slice(0, 3), torch::indexing::Slice(0, 3)});
+        torch::Tensor T = w2c.index({torch::indexing::Slice(0, 3), 3});
+
+        float fx = intr[0][0];
+        float fy = intr[1][1];
+        float cx = intr[0][2];
+        float cy = intr[1][2];
+
+        Camera cam(R,
+                   T,
+                   fx,
+                   fy,
+                   cx,
+                   cy,
+                   torch::empty({0}, torch::kFloat32),
+                   torch::empty({0}, torch::kFloat32),
+                   gsplat::CameraModelType::PINHOLE,
+                   img_id,
+                   "",
+                   width,
+                   height,
+                   cam_idx);
+
+        auto output = gs::rasterize(cam, model, bg_color);
+        std::filesystem::path out_path = out_dir / (img_id + ".png");
+        save_image(out_path, output.image);
+        std::cout << "Saved " << out_path << "\n";
+        ++cam_idx;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement command-line argument parsing in `render_from_json.cpp`
- build a `render_json` tool that loads a PLY Gaussian and camera JSON
- document how to use the helper and add note about `--help` option

## Testing
- `bash tools/pre-commit`
- `cmake -S . -B build -GNinja` *(fails: Could not find toolchain file)*

------
https://chatgpt.com/codex/tasks/task_e_68821787c108832981f4a3a520852b40