### PR TITLE
Add CameraInfo parser in JSON renderer

### DIFF
--- a/tools/render_from_json.cpp
+++ b/tools/render_from_json.cpp
@@ -8,6 +8,59 @@
 #include <iostream>
 #include <nlohmann/json.hpp>
 
+struct CameraInfo {
+    int uid;
+    torch::Tensor R;
+    torch::Tensor T;
+    float fov_x;
+    float fov_y;
+    torch::Tensor principal;
+    int width;
+    int height;
+    std::string name;
+};
+
+static CameraInfo parse_camera_json(const nlohmann::json& cam_json, int idx)
+{
+    CameraInfo info{};
+    info.uid = idx;
+    info.name = cam_json.value("img_id", std::to_string(idx));
+
+    auto intr = cam_json["intrinsics"];
+    auto ext = cam_json["extrinsics"]["c2w_matrix"];
+    info.width = cam_json.value("width", 0);
+    info.height = cam_json.value("height", 0);
+
+    torch::Tensor c2w = torch::empty({4, 4}, torch::kFloat32);
+    for (int i = 0; i < 4; ++i) {
+        for (int j = 0; j < 4; ++j) { c2w[i][j] = static_cast<float>(ext[i][j]); }
+    }
+
+    // c2w[:3, 1:3] *= -1
+    c2w.index({torch::indexing::Slice(0, 3), torch::indexing::Slice(1, 3)}) *=
+        -1.f;
+
+    torch::Tensor w2c = torch::inverse(c2w);
+
+    // R is stored transposed due to glm in the CUDA code
+    info.R = w2c.index({torch::indexing::Slice(0, 3),
+                        torch::indexing::Slice(0, 3)}).t();
+    info.T = w2c.index({torch::indexing::Slice(0, 3), 3});
+
+    float fx = intr[0][0];
+    float fy = intr[1][1];
+    float cx = intr[0][2];
+    float cy = intr[1][2];
+
+    info.fov_x = 2.f * std::atan(info.width / (2.f * fx));
+    info.fov_y = 2.f * std::atan(info.height / (2.f * fy));
+
+    info.principal =
+        torch::tensor({1.f - cx / info.width, 1.f - cy / info.height});
+
+    return info;
+}
+
 int main(int argc, char** argv) {
     args::ArgumentParser parser(
         "Render Gaussian Splat from JSON cameras",
@@ -79,29 +132,15 @@ int main(int argc, char** argv) {
             std::cerr << "Camera entry missing intrinsics or extrinsics\n";
             continue;
         }
-        auto intr = cam_json["intrinsics"];
-        auto ext = cam_json["extrinsics"]["c2w_matrix"];
-        int width = cam_json.value("width", 0);
-        int height = cam_json.value("height", 0);
-        std::string img_id = cam_json.value("img_id", std::to_string(cam_idx));
 
-        torch::Tensor c2w = torch::empty({4, 4}, torch::kFloat32);
-        for (int i = 0; i < 4; ++i) {
-            for (int j = 0; j < 4; ++j) {
-                c2w[i][j] = static_cast<float>(ext[i][j]);
-            }
-        }
-        torch::Tensor w2c = torch::inverse(c2w);
-        torch::Tensor R = w2c.index({torch::indexing::Slice(0, 3), torch::indexing::Slice(0, 3)});
-        torch::Tensor T = w2c.index({torch::indexing::Slice(0, 3), 3});
+        CameraInfo info = parse_camera_json(cam_json, cam_idx);
 
-        float fx = intr[0][0];
-        float fy = intr[1][1];
-        float cx = intr[0][2];
-        float cy = intr[1][2];
-
-        Camera cam(R,
-                   T,
+        float fx = cam_json["intrinsics"][0][0];
+        float fy = cam_json["intrinsics"][1][1];
+        float cx = cam_json["intrinsics"][0][2];
+        float cy = cam_json["intrinsics"][1][2];
+        Camera cam(info.R.t(),
+                   info.T,
                    fx,
                    fy,
                    cx,
@@ -109,14 +148,14 @@ int main(int argc, char** argv) {
                    torch::empty({0}, torch::kFloat32),
                    torch::empty({0}, torch::kFloat32),
                    gsplat::CameraModelType::PINHOLE,
-                   img_id,
+                   info.name,
                    "",
-                   width,
-                   height,
+                   info.width,
+                   info.height,
                    cam_idx);
 
         auto output = gs::rasterize(cam, model, bg_color);
-        std::filesystem::path out_path = out_dir / (img_id + ".png");
+        std::filesystem::path out_path = out_dir / (info.name + ".png");
         save_image(out_path, output.image);
         std::cout << "Saved " << out_path << "\n";
         ++cam_idx;


### PR DESCRIPTION
## Summary
- create `CameraInfo` struct and parsing helper
- use `parse_camera_json` when reading cameras in `render_from_json.cpp`
- output images using the parsed camera name

## Testing
- `./tools/pre-commit`
- `cmake -S . -B build` *(fails: Could not find toolchain file)*

------
https://chatgpt.com/codex/tasks/task_e_68832c75360483298bd810b4562786e3